### PR TITLE
feat(index.js): use runtimeConfig to set options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,14 @@ const moduleName = parsePackagejsonName(packageConfig.name).fullName;
 
 export default function (moduleOptions, nuxt) {
   nuxt = nuxt || this;
-  const options = { ...nuxt.options.mail, ...moduleOptions };
+
+  const runtimeConfig = useRuntimeConfig();
+
+  const options = {
+    ...runtimeConfig.mail,
+    ...nuxt.options.mail,
+    ...moduleOptions,
+  };
 
   if (!options.smtp) {
     throw new Error('SMTP config is missing.');


### PR DESCRIPTION
Nuxt allows you to use environment variables through useRuntimeConfig. This is preferable when you want different settings in different environments, and want to use secrets (e.g. SMTP username and password) without exposing them in nuxt.config.ts. This change adds `runtimeConfig.mail` options to the options object.

fix #120