### PR TITLE
Use the useRuntimeConfig() composable instead of static options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   addTemplate,
   createResolver,
   isNuxt3 as isNuxt3Try,
+  useRuntimeConfig,
 } from '@nuxt/kit';
 import express from 'express';
 import fs from 'fs-extra';
@@ -22,8 +23,17 @@ const moduleName = parsePackagejsonName(packageConfig.name).fullName;
 
 export default function (moduleOptions, nuxt) {
   nuxt = nuxt || this;
+  let isNuxt3 = true;
 
-  const runtimeConfig = useRuntimeConfig();
+  try {
+    isNuxt3 = isNuxt3Try();
+  } catch {
+    isNuxt3 = false;
+  }
+
+  const runtimeConfig = isNuxt3
+    ? useRuntimeConfig()
+    : nuxt.options.privateRuntimeConfig;
 
   const options = {
     ...runtimeConfig.mail,
@@ -48,14 +58,6 @@ export default function (moduleOptions, nuxt) {
 
   if (some(c => !c.to && !c.cc && !c.bcc)(options.message)) {
     throw new Error('You have to provide to/cc/bcc in all configs.');
-  }
-
-  let isNuxt3 = true;
-
-  try {
-    isNuxt3 = isNuxt3Try();
-  } catch {
-    isNuxt3 = false;
   }
 
   if (isNuxt3) {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,14 @@ const moduleName = parsePackagejsonName(packageConfig.name).fullName;
 
 export default function (moduleOptions, nuxt) {
   nuxt = nuxt || this;
-  const options = { ...nuxt.options.mail, ...moduleOptions };
+
+  const runtimeConfig = useRuntimeConfig();
+
+  const options = {
+    ...runtimeConfig.mail,
+    ...nuxt.options.mail,
+    ...moduleOptions,
+  };
 
   if (!options.smtp) {
     throw new Error('SMTP config is missing.');


### PR DESCRIPTION
Using `nuxt.options.runtimeConfig` returns static options from `nuxt.config.ts`. If you use the results of `useRuntimeConfig()` then those values are updated by environment variables.